### PR TITLE
Get rid of false error regarding finding OpenMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ set( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${GENESIS_EXE_LINKER_FLAG
 include_directories( "tclap/include" )
 
 # Genesis export the OpenMP variable. We use it to check and give advice in case it is not found.
-if( NOT OPENMP_FOUND )
+if( NOT ${OPENMP_FOUND} )
     string(ASCII 27 Esc)
     message( STATUS "${Esc}[31m"
         "Could not find OpenMP. This results in a considerably slower runtime for the program. Try "


### PR DESCRIPTION
I am on Linux. On running `make` I get the following error:
```
...
-- Looking for OpenMP
-- Found OpenMP_C: -fopenmp (found version "4.5") 
-- Found OpenMP_CXX: -fopenmp (found version "4.5") 
-- Found OpenMP: TRUE (found version "4.5")  
-- Found OpenMP: -fopenmp
-- Using OpenMP
-- Building static lib
-- Could not find OpenMP. This results in a considerably slower runtime for the program. Try to use a different compiler. Alternatively, if you are sure your compiler supports OpenMP, you can add the needed compiler flags to the CMake script. See BUILD.md for details.
...
```
However, I indeed have OpenMP (as cmake initially reports), and confirm upon running that the program is using multiple cores. The issue appears to involve [this test](https://github.com/lutteropp/QuartetScores/blob/master/CMakeLists.txt#L103). I gather that this information is to be exported from [genesis](https://github.com/lczech/genesis) but for whatever reason it does not work. I have found that using `${OPENMP_FOUND}`the (from [here](https://github.com/lczech/genesis/blob/616a7d468a5fd9cdb06e1e80efbe95283c0abeab/CMakeLists.txt#L405)) instead of the existing `OPENMP_FOUND` works correctly. 

I'm not sure if this is the ideal solution (I do not use cmake regularly) but hope this helps.